### PR TITLE
Fix the CMake build errors that happens in the windows test workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: choco install llvm
+        run: |
+          choco install git
+          git submodule update --init --recursive
+          choco install llvm
 
       - name: Check clang-format version
         run: clang-format --version

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Install dependencies
         run: |
@@ -47,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - "main"
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - "main"
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,10 +18,7 @@ jobs:
           submodules: recursive
 
       - name: Install dependencies
-        run: |
-          choco install git
-          git submodule update --init --recursive
-          choco install llvm
+        run: choco install llvm
 
       - name: Check clang-format version
         run: clang-format --version


### PR DESCRIPTION
The submodules in the repo were not being checked out at any point in the workflow, so it needed to be added.