### PR TITLE
Fix Linux workflow is failing at the clang-format step

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - "main"
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,18 +49,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install dependencies
-        run: |
-          sudo apt install clang-format-16
-
-      - name: Check clang-format version
-        run: clang-format --version
-
-      - name: Clang format check
-        run: |
-          find . -name '*.cpp' -or -name '*.h' | xargs clang-format -i --style=file
-          git diff
-
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt update && sudo apt upgrade
           wget https://apt.llvm.org/llvm.sh
           chmod u+x llvm.sh
           sudo ./llvm.sh 16
@@ -54,7 +55,7 @@ jobs:
 
       - name: Clang format check
         run: |
-          find . -name '*.cpp' -or -name '*.h' | xargs clang-format-16 -i --style=file
+          find . -name '*.cpp' -or -name '*.h' | xargs clang-format -i --style=file
           git diff
 
       - name: Create Build Environment

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -51,10 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update && sudo apt upgrade
-          wget https://apt.llvm.org/llvm.sh
-          chmod u+x llvm.sh
-          sudo ./llvm.sh 16
+          sudo apt install clang-format-16
 
       - name: Check clang-format version
         run: clang-format --version

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,12 +49,12 @@ jobs:
           chmod u+x llvm.sh
           sudo ./llvm.sh 16
 
-      - name: Check clang-format-16 version
-        run: clang-format-16 --version
+      - name: Check clang-format version
+        run: clang-format --version
 
       - name: Clang format check
         run: |
-          find . -name '*.cpp' -or -name '*.h' | xargs clang-format -i --style=file
+          find . -name '*.cpp' -or -name '*.h' | xargs clang-format-16 -i --style=file
           git diff
 
       - name: Create Build Environment

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - "main"
   pull_request:
     branches:
       - "main"
@@ -51,8 +49,8 @@ jobs:
           chmod u+x llvm.sh
           sudo ./llvm.sh 16
 
-      - name: Check clang-format version
-        run: clang-format --version
+      - name: Check clang-format-16 version
+        run: clang-format-16 --version
 
       - name: Clang format check
         run: |


### PR DESCRIPTION
The clang format version being installed is v14, which doesn't match the windows version or the config file for the clang formatting, so it fails. Either rollback to a common older version on windows too or try to find a way to install the latest version on Linux also.